### PR TITLE
Normalize server uri to have _no_ trailing slash

### DIFF
--- a/src/Entity/IppServer.php
+++ b/src/Entity/IppServer.php
@@ -17,7 +17,7 @@ class IppServer
 
     public function setUri(string $uri): self
     {
-        $this->uri = $uri;
+        $this->uri = rtrim($uri, '/');
 
         return $this;
     }

--- a/tests/Unit/Entity/IppServerTest.php
+++ b/tests/Unit/Entity/IppServerTest.php
@@ -14,8 +14,15 @@ class IppServerTest extends TestCase
 {
     use AccessorPairAsserter;
 
-    public function test(): void
+    public function testAccessorPairs(): void
     {
         self::assertAccessorPairs(IppServer::class);
+    }
+
+    public function testUriAccessorWithTrailingSlash(): void
+    {
+        $server = new IppServer();
+        $server->setUri('http://example.com/ipp/');
+        static::assertSame('http://example.com/ipp', $server->getUri());
     }
 }


### PR DESCRIPTION
Allow a little bit more robustness when configuring the cups server url. Currently when the cups server url ends with `/` certain urls will contain double slashes. Allow setting IppServer uri with an url with and without trailing `/`.